### PR TITLE
Fix Python3 map being a generator not a list

### DIFF
--- a/panphon/segment.py
+++ b/panphon/segment.py
@@ -98,7 +98,7 @@ class Segment(object):
             Segment: (name, value) pairs for each shared feature
         """
         data = dict(set(self.items()) & set(other.items()))
-        names = filter(lambda a: a in data, self.names)
+        names = list(filter(lambda a: a in data, self.names))
         return Segment(names, data)
 
     def __and__(self, other):
@@ -115,7 +115,7 @@ class Segment(object):
         """Return feature values as a list of strings"""
         if not names:
             names = self.names
-        return map(lambda x: self.n2s[x], self.numeric())
+        return list(map(lambda x: self.n2s[x], self.numeric()))
 
     def distance(self, other):
         """Compute a distance between `self` and `other`


### PR DESCRIPTION
Old `word_to_vector_list` returned a list of generators instead of a list of vector_lists

```
======================================================================
FAIL: test_ipa_vector_equals_xsampa_vector (test_xsampa.TestXSampa)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/sethtroisi/Projects/panphon/panphon/test/test_xsampa.py", line 23, in test_ipa_vector_equals_xsampa_vector
    self.assertEqual(ipa, xs)
AssertionError: Lists differ: [<map[17 chars]0c01b6a0>, <map object at 0x7fe20c01b710>, <ma[23 chars]780>] != [<map[17 chars]0c01b898>, <map object at 0x7fe20c01b908>, <ma[23 chars]978>]

First differing element 0:
<map object at 0x7fe20c01b6a0>
<map object at 0x7fe20c01b898>

- [<map object at 0x7fe20c01b6a0>,
?                            ^^^

+ [<map object at 0x7fe20c01b898>,
?                            ^^^

-  <map object at 0x7fe20c01b710>,
?                            ^^

+  <map object at 0x7fe20c01b908>,
?                            ^ +

-  <map object at 0x7fe20c01b780>]
?                              -

+  <map object at 0x7fe20c01b978>]
```