### PR TITLE
fix: use yaml FullLoader

### DIFF
--- a/panphon/collapse.py
+++ b/panphon/collapse.py
@@ -22,7 +22,7 @@ class Collapser(object):
         fn = pkg_resources.resource_filename(__name__, fn)
         with open(fn, 'r') as f:
             rules = []
-            table = yaml.load(f.read())
+            table = yaml.load(f.read(), Loader=yaml.FullLoader)
             for rule in table:
                 rules.append((_panphon.fts(rule['def']), rule['label']))
         return rules

--- a/panphon/distance.py
+++ b/panphon/distance.py
@@ -70,7 +70,7 @@ class Distance(object):
             __name__, filename)
         with open(filename, 'r') as f:
             rules = []
-            dogol_prime = yaml.load(f.read())
+            dogol_prime = yaml.load(f.read(), Loader=yaml.FullLoader)
             for rule in dogol_prime:
                 rules.append((ftstr2dict(rule['def']), rule['label']))
         return rules

--- a/panphon/permissive.py
+++ b/panphon/permissive.py
@@ -69,7 +69,7 @@ class PermissiveFeatureTable(_panphon.FeatureTable):
     def _read_dias(self, fn):
         prefix, postfix = {}, {}
         with codecs.open(fn, 'r', 'utf-8') as f:
-            defs = yaml.load(f.read())
+            defs = yaml.load(f.read(), Loader=yaml.FullLoader)
             for dia in defs['diacritics']:
                 if dia['position'] == 'pre':
                     prefix[dia['marker']] = dia['content']


### PR DESCRIPTION
Thanks @dmort27 for this great library. It's a cornerstone of one of our projects. 

We get a [deprecation warning](https://msg.pyyaml.org/load) because some calls to `yaml.load` don't specify a loader. This PR just adds the `yaml.FullLoader` explicitly everywhere `yaml.load` is called.