### PR TITLE
Feature error rate is 24 times higher than it should be

### DIFF
--- a/panphon/distance.py
+++ b/panphon/distance.py
@@ -404,7 +404,9 @@ class Distance(object):
         """
         if hyp and ref:
             errors = sum([self.feature_edit_distance(h, r) for (h, r) in zip(hyp, ref)])
-            return errors/len(''.join(ref))
+            ft = featuretable.FeatureTable()
+            total_phones = sum([len(ft.ipa_segs(r)) for r in ref])
+            return errors / total_phones
         else:
             return 0.0
 

--- a/panphon/distance.py
+++ b/panphon/distance.py
@@ -403,12 +403,8 @@ class Distance(object):
 
         """
         if hyp and ref:
-            try:
-                n_features = len(self.fm.word_to_vector_list(ref[0])[0])
-            except IndexError:
-                n_features = 23
             errors = sum([self.feature_edit_distance(h, r) for (h, r) in zip(hyp, ref)])
-            return errors/len(''.join(ref)) * n_features
+            return errors/len(''.join(ref))
         else:
             return 0.0
 


### PR DESCRIPTION
@cuichenx and I found it weird that the feature error rate was exceeding 100% since the total number of edits is at most 23/24/25, and we divide by 23/24/25

The feature error rate does not need to divide by number of feature because feature_edit_distance already does so.

```
import panphon.distance
dist = panphon.distance.Distance()
hyp = ["t", "t", "t"]
ref = ["tʰ", "d", "tʰ"]

print(sum([dist.feature_edit_distance(h, r) for (h, r) in zip(hyp, ref)]))
# [0.041666666666666664, 0.041666666666666664, 0.041666666666666664]
# or [1/24, 1/24, 1/24]
```

The feature error rate should be (3/72) / 3 since 3 features are different out of 24 + 24 + 24 total features. 