### PR TITLE
add triphthongize option

### DIFF
--- a/panphon/featuretable.py
+++ b/panphon/featuretable.py
@@ -79,6 +79,94 @@ class FeatureTable(object):
             node[self.TRIE_LEAF_MARKER] = None
         return trie
 
+    def _triphthongize(self, fts, word):
+        """Return a list of triphthong-ized Segments.
+        """
+        def get_seg_type(segment):
+            is_syllabic = segment['syl'] == 1
+            is_vowel = segment['cons'] == -1
+            is_tone = segment['syl'] == 0
+
+            if is_syllabic and is_vowel:
+                seg_type = 1  # vowel
+            elif not is_syllabic and is_vowel:
+                seg_type = 2  # semivowel
+            elif is_tone:
+                seg_type = 3  # tone
+            else:
+                seg_type = 4  # other
+
+            return seg_type
+
+        def zero_seg_like(segment):
+            names = segment.names
+            weights = segment.weights
+            return Segment(
+                names=names,
+                features={},
+                weights=weights
+            )
+
+        seg_types = [get_seg_type(segment) for segment in fts]
+
+        patterns = [
+            [4],
+            [1, 2], [1],
+            [2, 1, 2], [2, 1], [2],
+            [3, 3, 3], [3, 3], [3]
+        ]  # order is important - enforces priority
+
+        ret = []
+        _ret = []
+        _ret1 = []
+        __ret = []
+        __ret1 = []
+        idx = 0
+
+        ###########
+        ipa_segs = self.ipa_segs(word)
+
+        while idx < len(fts):
+            for seg_type_pattern in patterns:
+                if seg_types[idx: idx + len(seg_type_pattern)] == seg_type_pattern:
+                    triphthongized = fts[idx: idx + len(seg_type_pattern)]
+                    _ret.append(seg_type_pattern)
+                    _ret1.append(ipa_segs[idx: idx + len(seg_type_pattern)])
+                    
+                    # pad with placeholder (all-zero) segments
+                    sample_seg = triphthongized[0]
+                    if len(triphthongized) == 1:
+                        triphthongized = [zero_seg_like(sample_seg)] \
+                                         + triphthongized + [zero_seg_like(sample_seg)]
+
+                        __ret.append([0] + seg_type_pattern + [0])
+                        __ret1.append([0] + ipa_segs[idx: idx + len(seg_type_pattern)] + [0]) 
+                    elif len(triphthongized) == 2:
+                        if seg_type_pattern[0] == 1:
+                            triphthongized = [zero_seg_like(sample_seg)] + triphthongized
+
+                            __ret.append([0] + seg_type_pattern)
+                            __ret1.append([0] + ipa_segs[idx: idx + len(seg_type_pattern)])
+                        elif seg_type_pattern[1] in {1, 3}:
+                            triphthongized = triphthongized + [zero_seg_like(sample_seg)]
+                            
+                            __ret.append(seg_type_pattern + [0])
+                            __ret1.append(ipa_segs[idx: idx + len(seg_type_pattern)] + [0])
+                    else:
+                        __ret.append(seg_type_pattern)
+                        __ret1.append(ipa_segs[idx: idx + len(seg_type_pattern)])
+
+                    ret.append(triphthongized)
+                    idx += len(seg_type_pattern)
+                    break  # skip remaining patterns
+
+        print(ipa_segs)#, [get_seg_type(v) for v in fts])
+        print(_ret1)#, _ret)
+        print(__ret1)#, __ret)
+        print()
+
+        return ret
+
     def fts(self, ipa, normalize=True):
         if normalize:
             ipa = FeatureTable.normalize(ipa)
@@ -136,7 +224,7 @@ class FeatureTable(object):
         """
         return not self._segs(word, include_valid=False, include_invalid=True, normalize=normalize)
 
-    def word_fts(self, word, normalize=True):
+    def word_fts(self, word, normalize=True, triphthongize=False):
         """Return a list of Segment objects corresponding to the segments in
            word.
 
@@ -147,7 +235,11 @@ class FeatureTable(object):
         Returns:
             list: list of Segment objects corresponding to word
         """
-        return [self.fts(ipa, False) for ipa in self.ipa_segs(word, normalize)]
+        fts = [self.fts(ipa, False) for ipa in self.ipa_segs(word, normalize)]
+        if triphthongize:
+            return self._triphthongize(fts, word)
+        else:
+            return fts
 
     def word_array(self, ft_names, word, normalize=True):
         """Return a nparray of features namd in ft_name for the segments in word


### PR DESCRIPTION
# triphthong-ize

## Summary
* add triphthong-izing option to the  `word_fts()` function of the `FeatureTable` class
* The original `FeatureTable.word_fts()` returns a 1-dimensional array of `Segment` objects
* With this new feature, when `triphthongize` is set to `True`, it will return a 2-dimensional array
   *  Each element of the first dimension is a length-3 list of `Segment` objects
   *  Each of the 3 `Segment` objects correponds to _[prefix, base, suffix]_
* The returned form is standardized to length-3 lists to accommodate a maximum length-3 cluster (triphthong, length-3 tone)
* triphthong-izing chunks the following types of segment sequences into a single cluster:
   * consecutive sequence of vowels and semivowels &rarr; diphthong or triphthong
   * consecutive tones

## Behaviors
#### general
* In clusters with 1 or 2 `Segment` objects, the empty spots are filled with a padding `Segment`, where all feature values are 0
   * ex) monophthongs, diphthongs, consonants, tones of length 1~2, etc.
* length-1 clusters are always padded in the start and the end
* length-2 clusters can be padded either at the start or at the end, depending on the specific sequence (explained below)

#### semivowels & vowels
* The vowel always takes the _base_ position
* The semivowel(s) take prefix and/or suffix positions
* phonetic conditions to extract vowels/semivowels
   * vowel: [+syl, -cons]
   * semivowel: [-syl, -cons]
* In ambiguous cases, a semivowel prefers its preceding vowel over its following vowel
* sequence types
   |type|original|padded|example|
   |--|--|--|--|
   |monophthong|[**vowel**]|[0, **vowel**, 0]|`[0 ə, 0]`|
   |diphthong|[semivowel + **vowel**]|[semivowel, **vowel**, 0]|`[i̯, ə, 0]`|
   |diphthong|[**vowel** + semivowel]|[0, **vowel**, semivowel]|`[0, ə, u̯]`|
   |triphthong|[semivowel + **vowel** + semivowel]|[semivowel + **vowel** + semivowel]|`[i̯, ə, u̯]`|

#### tones
* tones can have length between 1~3
* length-2 tones are always padded at the end (2nd tone is always treated as the base)
* sequence types
   |type|original|padded|example|
   |--|--|--|--|
   |length-1|[**tone**]|[0, **tone**, 0]|`[0, ˥, 0]`|
   |length-2|[tone1, **tone2**]|[tone1, **tone2**, 0]|`[˥, ˦, 0]`|
   |length-3|[tone1, **tone2**, tone3]|[tone1, **tone2**, tone3]|`[˧, ˩, ˨]`|

#### consonants
* consonants are always stand-alone `Segment`s and thus padded on both sides
* sequence types
   |type|original|padded|example|
   |--|--|--|--|
   |length-1|[**cons**]|[0, **cons**, 0]|`[0, t͡ɕʰ, 0]`|

## Example
#### Flow
0. original ipa sequence: `bi̯ɛn˥˩`
5. diphthong/triphthong clustering: `[b], [i̯ɛ], [n], [˥˩]`
6. monophthong/diphthong padding: `[0, b, 0], [i̯, ɛ, 0], [0, n, 0], [˥, ˩, 0]`
(`0` refers to padding segment (all-zero features))

#### Return value of `word_fts()`

* `triphthongize = False` (original)
```python3
[
# b
 <Segment [-syl, -son, +cons, -cont, -delrel, -lat, -nas, 0strid, +voi, -sg, -cg, +ant, -cor, 0distr, +lab, -hi, -lo, -back, -round, -velaric, 0tense, -long, 0hitone, 0hireg]>,
# i̯
 <Segment [-syl, +son, -cons, +cont, -delrel, -lat, -nas, 0strid, +voi, -sg, -cg, 0ant, -cor, 0distr, -lab, +hi, -lo, -back, -round, -velaric, +tense, -long, 0hitone, 0hireg]>,
# ɛ
 <Segment [+syl, +son, -cons, +cont, -delrel, -lat, -nas, 0strid, +voi, -sg, -cg, 0ant, -cor, 0distr, -lab, -hi, -lo, -back, -round, -velaric, -tense, -long, 0hitone, 0hireg]>,
# n
 <Segment [-syl, +son, +cons, -cont, -delrel, -lat, +nas, 0strid, +voi, -sg, -cg, +ant, +cor, -distr, -lab, -hi, -lo, -back, -round, -velaric, 0tense, -long, 0hitone, 0hireg]>,
# ˥
 <Segment [0syl, 0son, 0cons, 0cont, 0delrel, 0lat, 0nas, 0strid, 0voi, 0sg, 0cg, 0ant, 0cor, 0distr, 0lab, 0hi, 0lo, 0back, 0round, 0velaric, 0tense, 0long, +hitone, +hireg]>,
# ˩
 <Segment [0syl, 0son, 0cons, 0cont, 0delrel, 0lat, 0nas, 0strid, 0voi, 0sg, 0cg, 0ant, 0cor, 0distr, 0lab, 0hi, 0lo, 0back, 0round, 0velaric, 0tense, 0long, -hitone, -hireg]>
]
```

* `triphthongize = True` (added in this PR)
```python3
[
 [
  # 0
  <Segment [0syl, 0son, 0cons, 0cont, 0delrel, 0lat, 0nas, 0strid, 0voi, 0sg, 0cg, 0ant, 0cor, 0distr, 0lab, 0hi, 0lo, 0back, 0round, 0velaric, 0tense, 0long, 0hitone, 0hireg]>,
  # b
  <Segment [-syl, -son, +cons, -cont, -delrel, -lat, -nas, 0strid, +voi, -sg, -cg, +ant, -cor, 0distr, +lab, -hi, -lo, -back, -round, -velaric, 0tense, -long, 0hitone, 0hireg]>,
  # 0
  <Segment [0syl, 0son, 0cons, 0cont, 0delrel, 0lat, 0nas, 0strid, 0voi, 0sg, 0cg, 0ant, 0cor, 0distr, 0lab, 0hi, 0lo, 0back, 0round, 0velaric, 0tense, 0long, 0hitone, 0hireg]>
 ],
 [
  # i̯
  <Segment [-syl, +son, -cons, +cont, -delrel, -lat, -nas, 0strid, +voi, -sg, -cg, 0ant, -cor, 0distr, -lab, +hi, -lo, -back, -round, -velaric, +tense, -long, 0hitone, 0hireg]>,
  # ɛ
  <Segment [+syl, +son, -cons, +cont, -delrel, -lat, -nas, 0strid, +voi, -sg, -cg, 0ant, -cor, 0distr, -lab, -hi, -lo, -back, -round, -velaric, -tense, -long, 0hitone, 0hireg]>,
  # 0
  <Segment [0syl, 0son, 0cons, 0cont, 0delrel, 0lat, 0nas, 0strid, 0voi, 0sg, 0cg, 0ant, 0cor, 0distr, 0lab, 0hi, 0lo, 0back, 0round, 0velaric, 0tense, 0long, 0hitone, 0hireg]>
 ],
 [
  # 0
  <Segment [0syl, 0son, 0cons, 0cont, 0delrel, 0lat, 0nas, 0strid, 0voi, 0sg, 0cg, 0ant, 0cor, 0distr, 0lab, 0hi, 0lo, 0back, 0round, 0velaric, 0tense, 0long, 0hitone, 0hireg]>,
  # n
  <Segment [-syl, +son, +cons, -cont, -delrel, -lat, +nas, 0strid, +voi, -sg, -cg, +ant, +cor, -distr, -lab, -hi, -lo, -back, -round, -velaric, 0tense, -long, 0hitone, 0hireg]>,
  # 0
  <Segment [0syl, 0son, 0cons, 0cont, 0delrel, 0lat, 0nas, 0strid, 0voi, 0sg, 0cg, 0ant, 0cor, 0distr, 0lab, 0hi, 0lo, 0back, 0round, 0velaric, 0tense, 0long, 0hitone, 0hireg]>
 ],
 [
  # ˥
  <Segment [0syl, 0son, 0cons, 0cont, 0delrel, 0lat, 0nas, 0strid, 0voi, 0sg, 0cg, 0ant, 0cor, 0distr, 0lab, 0hi, 0lo, 0back, 0round, 0velaric, 0tense, 0long, +hitone, +hireg]>,
  # ˩
  <Segment [0syl, 0son, 0cons, 0cont, 0delrel, 0lat, 0nas, 0strid, 0voi, 0sg, 0cg, 0ant, 0cor, 0distr, 0lab, 0hi, 0lo, 0back, 0round, 0velaric, 0tense, 0long, -hitone, -hireg]>,
  # 0
  <Segment [0syl, 0son, 0cons, 0cont, 0delrel, 0lat, 0nas, 0strid, 0voi, 0sg, 0cg, 0ant, 0cor, 0distr, 0lab, 0hi, 0lo, 0back, 0round, 0velaric, 0tense, 0long, 0hitone, 0hireg]>
 ]
]
```