### PR TITLE
Fixing encoding errors on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ target/
 .vscode/settings.json
 .DS_Store
 .gitignore
+
+
+venv

--- a/panphon/_panphon.py
+++ b/panphon/_panphon.py
@@ -140,7 +140,7 @@ class FeatureTable(object):
             __name__, filename)
         segments = []
         with open(filename, 'rb') as f:
-            reader = csv.reader(f, encoding='utf-8')
+            reader = csv.reader(f)
             header = next(reader)
             names = header[1:]
             for row in reader:
@@ -155,7 +155,7 @@ class FeatureTable(object):
         filename = pkg_resources.resource_filename(
             __name__, filename)
         with open(filename, 'rb') as f:
-            reader = csv.reader(f, encoding='utf-8')
+            reader = csv.reader(f)
             next(reader)
             weights = [float(x) for x in next(reader)]
         return weights

--- a/panphon/bin/align_wordlists.py
+++ b/panphon/bin/align_wordlists.py
@@ -44,8 +44,8 @@ def score(indices):
 
 def main(wordlist1, wordlist2, dist_funcs):
     with open(wordlist1, 'rb') as file_a, open(wordlist2, 'rb') as file_b:
-        reader_a = csv.reader(file_a, encoding='utf-8')
-        reader_b = csv.reader(file_b, encoding='utf-8')
+        reader_a = csv.reader(file_a)
+        reader_b = csv.reader(file_b)
         print('Reading word lists...')
         words = zip([(w, g) for (g, w) in reader_a],
                     [(w, g) for (g, w) in reader_b])

--- a/panphon/bin/generate_ipa_all.py
+++ b/panphon/bin/generate_ipa_all.py
@@ -134,7 +134,7 @@ def parse_dia_defs(dia_defs):
 
 def sort_all_segments(sort_order, all_segments):
     all_segments_list = list(all_segments)
-    field_order = reversed(yaml.load(open(sort_order, 'r').read(), Loader=yaml.FullLoader))
+    field_order = reversed(yaml.load(open(sort_order, 'r', encoding='utf-8').read(), Loader=yaml.FullLoader))
     for field in field_order:
         all_segments_list.sort(key=lambda seg: seg.features[field['name']],
                                reverse=field['reverse'])

--- a/panphon/bin/generate_ipa_all.py
+++ b/panphon/bin/generate_ipa_all.py
@@ -143,7 +143,7 @@ def sort_all_segments(sort_order, all_segments):
 
 def write_ipa_all(ipa_bases, ipa_all, all_segments, sort_order):
     with open(ipa_bases, 'rb') as f:
-        reader = csv.reader(f, encoding='utf-8')
+        reader = csv.reader(f)
         fieldnames = next(reader)
     with open(ipa_all, 'wb') as f:
         writer = csv.DictWriter(f, encoding='utf-8', fieldnames=fieldnames)

--- a/panphon/collapse.py
+++ b/panphon/collapse.py
@@ -20,7 +20,7 @@ class Collapser(object):
     def _load_table(self, tablename):
         fn = os.path.join('data', tablename)
         fn = pkg_resources.resource_filename(__name__, fn)
-        with open(fn, 'r') as f:
+        with open(fn, 'r', encoding='utf-8') as f:
             rules = []
             table = yaml.load(f.read(), Loader=yaml.FullLoader)
             for rule in table:

--- a/panphon/distance.py
+++ b/panphon/distance.py
@@ -67,7 +67,7 @@ class Distance(object):
         """
         filename = pkg_resources.resource_filename(
             __name__, filename)
-        with open(filename, 'r') as f:
+        with open(filename, 'r', encoding='utf-8') as f:
             rules = []
             dolgo_prime = yaml.load(f.read(), Loader=yaml.FullLoader)
             for rule in dolgo_prime:

--- a/panphon/featuretable.py
+++ b/panphon/featuretable.py
@@ -23,22 +23,23 @@ feature_sets = {
 }
 
 class SegmentSorter:
-    def __init__(self, segments,):
+    def __init__(self, segments):
         self._segments = segments
-        self._sorted=False
+        self._sorted = False
 
     @property
     def segments(self):
         if not self._sorted:
-            self.sort_segments()
+            self._sort_segments()
         return self._segments
 
-    def sort_segments(self):
-        self.segments.sort(key=self.segment_key)
+    def _sort_segments(self):
+        self._segments.sort(key=self.segment_key)
+        self._sorted = True
 
     @staticmethod
     def segment_key(segment_tuple):
-        segment_data=segment_tuple[1]
+        segment_data = segment_tuple[1]
         return (
             segment_data['syl'], segment_data['son'], segment_data['cons'], segment_data['cont'],
             segment_data['delrel'], segment_data['lat'], segment_data['nas'], segment_data['strid'],
@@ -65,7 +66,7 @@ class FeatureTable(object):
         self.longest_seg = max([len(x) for x in self.seg_dict.keys()])
         self.xsampa = xsampa.XSampa()
 
-        self.sorted_segments = SegmentSorter(self.segments) #used for quick binary searches
+        self.sorted_segments = SegmentSorter(self.segments)
 
 
 
@@ -542,18 +543,15 @@ class FeatureTable(object):
                 high = mid - 1
 
         if best_match_index is None and fuzzy_search:
-            # Used for fuzzy searching
             best_match_index = mid
 
         if best_match_index is not None:
-            # Check neighboring rows within the range of +-5
             best_match = segment_list[best_match_index]
             for offset in range(-9, 5):
                 neighbor_index = best_match_index + offset
                 if 0 <= neighbor_index < len(segment_list):
                     neighbor_segment = segment_list[neighbor_index]
-                    if not self._compare_vectors(self.sorted_segments.segment_key(neighbor_segment),target):
-                        # Check if the neighbor segment has a shorter name
+                    if not self._compare_vectors(self.sorted_segments.segment_key(neighbor_segment), target):
                         if len(neighbor_segment[0]) < len(best_match[0]):
                             best_match = neighbor_segment
             return best_match[0]

--- a/panphon/featuretable.py
+++ b/panphon/featuretable.py
@@ -76,7 +76,7 @@ class FeatureTable(object):
     def _read_bases(self, fn: str, weights):
         fn = pkg_resources.resource_filename(__name__, fn)
         segments = []
-        with open(fn) as f:
+        with open(fn, encoding='utf-8') as f:
             reader = csv.reader(f)
             header = next(reader)
             names = header[1:]
@@ -92,7 +92,7 @@ class FeatureTable(object):
 
     def _read_weights(self, weights_fn: str) -> list[float]:
         weights_fn = pkg_resources.resource_filename(__name__, weights_fn)
-        with open(weights_fn) as f:
+        with open(weights_fn, encoding='utf-8') as f:
             reader = csv.reader(f)
             next(reader)
             weights = [float(x) for x in next(reader)]

--- a/panphon/permissive.py
+++ b/panphon/permissive.py
@@ -58,7 +58,7 @@ class PermissiveFeatureTable(_panphon.FeatureTable):
     def _read_ipa_bases(self, fn):
         fn = pkg_resources.resource_filename(__name__, fn)
         with open(fn, 'rb') as f:
-            reader = csv.reader(f, encoding='utf-8', delimiter=str(','))
+            reader = csv.reader(f, delimiter=str(','))
             names = next(reader)[1:]
             bases = {}
             for row in reader:
@@ -93,7 +93,7 @@ class PermissiveFeatureTable(_panphon.FeatureTable):
         filename = pkg_resources.resource_filename(
             __name__, filename)
         with open(filename, 'rb') as f:
-            reader = csv.reader(f, encoding='utf-8')
+            reader = csv.reader(f)
             next(reader)
             weights = [float(x) for x in next(reader)]
         return weights

--- a/panphon/xsampa.py
+++ b/panphon/xsampa.py
@@ -14,7 +14,7 @@ class XSampa(object):
     def read_xsampa_table(self):
         filename = os.path.join('data', 'ipa-xsampa.csv')
         filename = pkg_resources.resource_filename(__name__, filename)
-        with open(filename, 'rb') as f:
+        with open(filename, 'rb', encoding='utf-8') as f:
             xs2ipa = {x[1]: x[0] for x in csv.reader(f, encoding='utf-8')}
         xs = sorted(xs2ipa.keys(), key=len, reverse=True)
         xs_regex = re.compile('|'.join(list(map(re.escape, xs))))

--- a/panphon/xsampa.py
+++ b/panphon/xsampa.py
@@ -14,8 +14,8 @@ class XSampa(object):
     def read_xsampa_table(self):
         filename = os.path.join('data', 'ipa-xsampa.csv')
         filename = pkg_resources.resource_filename(__name__, filename)
-        with open(filename, 'rb', encoding='utf-8') as f:
-            xs2ipa = {x[1]: x[0] for x in csv.reader(f, encoding='utf-8')}
+        with open(filename, 'rb') as f:
+            xs2ipa = {x[1]: x[0] for x in csv.reader(f)}
         xs = sorted(xs2ipa.keys(), key=len, reverse=True)
         xs_regex = re.compile('|'.join(list(map(re.escape, xs))))
         return xs_regex, xs2ipa


### PR DESCRIPTION
This mainly adds the `encoding='utf-8'` where appropriate so files open safely on Windows.

I also ran into a recursion error on test_featuretable.py. The issue appears to be a recursion problem in the SegmentSorter class. The segments property is calling sort_segments(), which in turn is accessing segments, creating an infinite loop. There, the changes made in featuretable.py are:

* Renamed sort_segments() to _sort_segments() to indicate it's a private method.
* In the segments property, we now call self._sort_segments() instead of self.sort_segments().
* In _sort_segments(), we set self._sorted = True after sorting.

All tests pass locally for me, on Mac and Windows.