### PR TITLE
fix: import Mapping from typing module

### DIFF
--- a/panphon/segment.py
+++ b/panphon/segment.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Iterable, Mapping
-from typing import TypeVar
+from typing import Iterator, Mapping, TypeVar
 import regex as re
 
 T = TypeVar('T')


### PR DESCRIPTION
in python 3.8 you cannot subscript the `collections.abc.Mapping` class so importing from `typing` is more stable across python versions

see https://stackoverflow.com/questions/59955751/abcmeta-object-is-not-subscriptable-when-trying-to-annotate-a-hash-variable