### PR TITLE
 Three small fixes for panphon on Windows and Python 3.12

### DIFF
--- a/panphon/featuretable.py
+++ b/panphon/featuretable.py
@@ -34,7 +34,7 @@ class SegmentSorter:
         return self._segments
 
     def sort_segments(self):
-        self.segments.sort(key=self.segment_key)
+        self._segments.sort(key=self.segment_key)
 
     @staticmethod
     def segment_key(segment_tuple):
@@ -76,7 +76,7 @@ class FeatureTable(object):
     def _read_bases(self, fn: str, weights):
         fn = pkg_resources.resource_filename(__name__, fn)
         segments = []
-        with open(fn) as f:
+        with open(fn, encoding="utf8") as f:
             reader = csv.reader(f)
             header = next(reader)
             names = header[1:]
@@ -585,4 +585,3 @@ class FeatureTable(object):
             word = self.xsampa.convert(word)
 
         return word
-

--- a/panphon/segment.py
+++ b/panphon/segment.py
@@ -12,7 +12,7 @@ class Segment(Mapping[str, int]):
     
     :param names list[str]: An ordered list of feature names.
     :param feature dict[str, int]: name-feature pairs for specified features.
-    :param ftstr str: A string, each /(+|0|-)\w+/ sequence of which is interpreted as a feature specification.
+    :param ftstr str: A string, each /(+|0|-)\\w+/ sequence of which is interpreted as a feature specification.
     :param weights list[float]: An ordered list of feature weights/saliences.
     """
     def __init__(self, names: list[str], features: dict[str, int]={}, ftstr: str='', weights: "list[float]"=[]):

--- a/panphon/segment.py
+++ b/panphon/segment.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Iterable, Mapping
-from typing import TypeVar
+from typing import Iterator, Mapping, TypeVar
 import regex as re
 
 T = TypeVar('T')


### PR DESCRIPTION
Three small fixes for panphon on Windows and Python 3.12:

1) On Python 3.12, I was getting infinite recursion in featuretable.py because sort_segments() used self.segments which called segments()   and thus sort_segments() again. Using the underlying self._segments   instead in sort_segments() removes the infinite recursion.

2) Also in featuretable.py, `with open(fn) as f:` on line 79 assumes   utf-8 on Linux, but it assumes cp-1252 on my Windows machine.   Declaring the encoding explicitly fixed the problem.   For code portability, it's unfortunately and very annoyingly required   to always declare the encoding when opening a file in text mode in   Python.

   There are other places in the code where text-mode open statements   don't declare the encoding. I'm not sure why those did not cause   problems in my tests.

3) Minor warning from Python 3.12: in the docstring, the \ in \w has to   be escaped so that `help(Segments)` get printed correctly.

I have tested these changes with python 3.8 and python 3.12 on a machine with Windows 10, using `python -m unittest panphon/test/test* ` to run all unit tests.

I discovered these problems while testing #57 on my machine. Note that this PR includes the commit from #57 because without it I could not test on Python 3.8.