### PR TITLE
Fix UnicodeDecodeError on Windows by explicitly setting UTF-8 encoding

### DIFF
--- a/panphon/featuretable.py
+++ b/panphon/featuretable.py
@@ -76,7 +76,7 @@ class FeatureTable(object):
     def _read_bases(self, fn: str, weights):
         fn = pkg_resources.resource_filename(__name__, fn)
         segments = []
-        with open(fn) as f:
+        with open(fn, encoding='utf-8') as f:
             reader = csv.reader(f)
             header = next(reader)
             names = header[1:]


### PR DESCRIPTION
Resolves dmort27/epitran#188

This specifies `encoidng='utf-8'` when opening `fn` in `FeatureTable._read_bases`. On Windows, the default encoding isn't utf-8 which causes the following error:
```UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 970: character maps to <undefined>` error when running `epi = epitran.Epitran("eng-Latn")```

This occurs when initializing Epitran with `epi = epitran.Epitran("eng-Latn")`